### PR TITLE
Add Fly deployment and fix streamlit missing code bug

### DIFF
--- a/.idea/centrality.iml
+++ b/.idea/centrality.iml
@@ -11,6 +11,7 @@
       <sourceFolder url="file://$MODULE_DIR$/vmagent" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/vmagent/vmagent" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/rapidui" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/rapidui/rapidui" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.ignore" />
       <excludeFolder url="file://$MODULE_DIR$/.ignore/venv" />
       <excludeFolder url="file://$MODULE_DIR$/.idea/dataSources" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN apt-get update  \
 # Install pip
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
 
+# Make Python 3.11 the default Python
+RUN ln -s /usr/bin/python3.11 /usr/bin/python
+
 # Copy the monorepo into the container
 COPY . /centrality
 WORKDIR /centrality

--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ python vmagent/vmagent/cli.py launch -f tests/configs/quicktest/vmagent.yaml
 flyctl deploy
 ```
 
+To deploy the agent cluster app
+
+```bash
+fly --config fly-agent-cluster.toml deploy
+fly --config fly-agent-cluster.toml scale count --process-group agent 5
+```
+
+To run a local VM Agent that talks to the Fly control plane:
+
+```bash
+python vmagent/vmagent/cli.py launch -f tests/configs/fly/vmagent-local.yaml
+```
+
 
 # Development
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,24 @@
 
 # Testing
 
-
 There are a couple forms of testing. 
 
-Docker compose (`dockercompose`) is the primary local development environment. This will spin up all the components locally with
-a small number of agents. It is easy to add and remove agents to test dynamism (see instructions at top of compose.yaml).
-This currently does a build of the Docker images, so it isn't super fast. This could be improved by mounting
-the source code into the containers, so a rebuild isn't necessary.
+Docker compose (`dockercompose`) is the primary local development environment. This will spin up all the 
+components locally with a small number of agents. It is easy to add and remove agents to test dynamism 
+(see instructions at top of compose.yaml). This currently does a build of the Docker images, so it isn't 
+super fast. This could be improved by mounting the source code into the containers, so a rebuild isn't 
+necessary.
 
-Python testing (`quicktest`) is also possible for rapid iteration, but it is preferable to do unit testing. However, if a 
-docker compose stack is running, it is possible to launch an agent/webui outside of docker for rapid
+Python testing (`quicktest`) is also possible for rapid iteration, but it is preferable to do unit testing. However, 
+if a docker compose stack is running, it is possible to launch an agent/webui outside of docker for rapid
 iteration. See the `quicktest` config for an example.
 
 There is a missing testing piece that allows us to simulate very large-scale deployments with ~1000+ agents. This
-will require external machines as my laptop isn't powerful enough to run that many agents. 
+will require external machines as my laptop isn't powerful enough to run that many agents. Possibly we can use a 
+single, very large machine with docker compose?
 
-Fly (`fly`) is the fully deployed environment. This hasn't been set up yet. Possibly there should be a dev and prod
-version of this environment. 
+Fly (`fly`) is the fully deployed environment. There is a fly application for the control plane + rapidui and a 
+separate fly application for the agent cluster. There is currently only a single Fly stack (i.e. no dev/prod).
 
 
 ## Docker Compose
@@ -30,11 +31,6 @@ docker compose build
 docker compose up
 ```
 
-```bash
-#python cli/cli/cli.py watch-vm
-python cli/cli/cli.py watch-cpu
-````
-
 ## Quick tests
 
 To quickly run a test outside of a container, you can use the `quicktest` config.
@@ -45,14 +41,19 @@ python vmagent/vmagent/cli.py launch -f tests/configs/quicktest/vmagent.yaml
 
 ## Fly
 
+To deploy the Fly applications:
+
 ```bash
-flyctl deploy
+# Control plane
+fly deploy
+
+# Agent cluster
+fly --config fly-agent-cluster.toml deploy
 ```
 
-To deploy the agent cluster app
+To scale the agent cluster.
 
 ```bash
-fly --config fly-agent-cluster.toml deploy
 fly --config fly-agent-cluster.toml scale count --process-group agent 5
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ To quickly run a test outside of a container, you can use the `quicktest` config
 python vmagent/vmagent/cli.py launch -f tests/configs/quicktest/vmagent.yaml
 ```
 
+## Fly
+
+```bash
+flyctl deploy
+```
+
 
 # Development
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -41,6 +41,17 @@ services:
     depends_on:
       - postgres
 
+  rapidui:
+    build: .
+    ports:
+      - "127.0.0.1:8501:8501"
+    environment:
+      - PYTHONUNBUFFERED=1
+    working_dir: /centrality/rapidui
+    command: "make launch"
+    depends_on:
+      - controlplane
+
   postgres:
     image: "postgres:16.1"
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -48,7 +48,7 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
     working_dir: /centrality/rapidui
-    command: "make launch"
+    command: "./launch.bash ../tests/configs/dockercompose/rapidui.yaml"
     depends_on:
       - controlplane
 

--- a/controlplane/README.md
+++ b/controlplane/README.md
@@ -6,3 +6,6 @@
 ```bash
 curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" -X GET http://localhost:8000/healthz/auth
 ```
+
+curl -H "Authorization: Bearer dev" -X GET https://centrality-dev.fly.dev:8000/vm/live
+

--- a/controlplane/README.md
+++ b/controlplane/README.md
@@ -7,5 +7,3 @@
 curl -H "Authorization: Bearer YOUR_ACCESS_TOKEN" -X GET http://localhost:8000/healthz/auth
 ```
 
-curl -H "Authorization: Bearer dev" -X GET https://centrality-dev.fly.dev:8000/vm/live
-

--- a/fly-agent-cluster.toml
+++ b/fly-agent-cluster.toml
@@ -11,7 +11,7 @@ primary_region = "iad"
 [http_service]
   internal_port = 7777
   force_https = true
-  min_machines_running = 1  # This appears to be uselsss. Use `fly scale count X` instead.
+  min_machines_running = 1  # This appears to be useless. Use `fly scale count X` instead.
   processes = ["agent"]
 
 [processes]

--- a/fly-agent-cluster.toml
+++ b/fly-agent-cluster.toml
@@ -1,0 +1,23 @@
+# fly.toml app configuration file generated for centrality-agent-cluster on 2023-12-23T21:39:42-05:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "centrality-agent-cluster"
+primary_region = "iad"
+
+[build]
+
+[http_service]
+  internal_port = 7777
+  force_https = true
+  min_machines_running = 1  # This appears to be uselsss. Use `fly scale count X` instead.
+  processes = ["agent"]
+
+[processes]
+  agent = "python vmagent/vmagent/cli.py launch -f tests/configs/fly/vmagent-auto.yaml --vm-id auto"
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 256

--- a/fly.toml
+++ b/fly.toml
@@ -8,16 +8,35 @@ primary_region = "iad"
 
 [build]
 
-[http_service]
+[[services]]
+  processes = ["fastapi"]
   internal_port = 8000
-  force_https = true
+  protocol = "tcp"
   auto_stop_machines = true
   auto_start_machines = true
   min_machines_running = 0
-  processes = ["fastapi"]
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+  #  handlers = ["tls", "http"]
+    port = "8000"
+#  force_https = true
+
+[[services]]
+  processes = ["streamlit"]
+  internal_port = 8501
+  protocol = "tcp"
+
+  [[services.ports]]
+    handlers = ["tls"]
+  #  handlers = ["tls", "http"]
+    port = "443"
+#  force_https = true
+
 
 [processes]
   fastapi = "python3.11 controlplane/controlplane/cli.py launch"
+  streamlit = "make -C rapidui launch-fly"
 
 [[vm]]
   cpu_kind = "shared"

--- a/fly.toml
+++ b/fly.toml
@@ -18,9 +18,7 @@ primary_region = "iad"
 
   [[services.ports]]
     handlers = ["tls", "http"]
-  #  handlers = ["tls", "http"]
     port = "8000"
-#  force_https = true
 
 [[services]]
   processes = ["streamlit"]
@@ -29,9 +27,7 @@ primary_region = "iad"
 
   [[services.ports]]
     handlers = ["tls"]
-  #  handlers = ["tls", "http"]
     port = "443"
-#  force_https = true
 
 
 [processes]

--- a/fly.toml
+++ b/fly.toml
@@ -35,7 +35,7 @@ primary_region = "iad"
 
 
 [processes]
-  fastapi = "python3.11 controlplane/controlplane/cli.py launch"
+  fastapi = "python controlplane/controlplane/cli.py launch"
   streamlit = "make -C rapidui launch-fly"
 
 [[vm]]

--- a/rapidui/Makefile
+++ b/rapidui/Makefile
@@ -13,3 +13,7 @@ format:
 launch:
 	./launch.bash ../tests/configs/quicktest/rapidui.yaml
 
+.PHONY: launch-fly
+launch-fly:
+	./launch.bash ../tests/configs/fly/rapidui.yaml
+

--- a/rapidui/config_util.py
+++ b/rapidui/config_util.py
@@ -2,7 +2,7 @@
 # in multi-page apps (if you want people to be able to go directly to a page via a URL instead of going
 # through the home page).
 
-from rapidui.lib.config import StreamlitUiConfig
+from rapidui.library.config import StreamlitUiConfig
 from pathlib import Path
 from typing import Annotated, Optional
 import typer

--- a/rapidui/rapidui/Home.py
+++ b/rapidui/rapidui/Home.py
@@ -1,5 +1,5 @@
 from rapidui.header import header
-from rapidui.lib.utils import load_config
+from rapidui.library.utils import load_config
 import typer
 
 

--- a/rapidui/rapidui/header.py
+++ b/rapidui/rapidui/header.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from rapidui.lib import constants
+from rapidui.library import constants
 from pathlib import Path
 
 GLOBAL_CSS_PATH = Path(__file__).parent / "app.css"

--- a/rapidui/rapidui/library/cluster_view.py
+++ b/rapidui/rapidui/library/cluster_view.py
@@ -2,9 +2,8 @@ from rapidui.library.flexbox import CardContents, BaseCard
 
 
 class MachineOverviewCardContents(CardContents):
-    def __init__(self, vm_id: str, avg_cpu: float):
-        self.vm_id = vm_id
-        self.avg_cpu = avg_cpu
+    vm_id: str
+    avg_cpu: float
 
 
 class MachineOverviewCard(BaseCard):

--- a/rapidui/rapidui/library/cluster_view.py
+++ b/rapidui/rapidui/library/cluster_view.py
@@ -32,7 +32,8 @@ class LiveMachineCount:
         self.machine_type = machine_type
         self.num_machines = num_machines
         self.machine_count_container = self.parent.empty()
-        # We need to set the background color of the container if we don't want to highlight it as a card
+        # We need to set the background color of the container to match the main background color if
+        # we don't want to highlight it as a card
         self.machine_count_container.markdown(
             self._gen_markdown(machine_type, num_machines),
             unsafe_allow_html=True,

--- a/rapidui/rapidui/library/cluster_view.py
+++ b/rapidui/rapidui/library/cluster_view.py
@@ -1,0 +1,58 @@
+from rapidui.library.flexbox import CardContents, BaseCard
+
+
+class MachineOverviewCardContents(CardContents):
+    def __init__(self, vm_id: str, avg_cpu: float):
+        self.vm_id = vm_id
+        self.avg_cpu = avg_cpu
+
+
+class MachineOverviewCard(BaseCard):
+    def __init__(self, parent_container, contents: MachineOverviewCardContents):
+        self.parent = parent_container
+        self.contents = contents
+
+        self.title = self.parent.empty()
+        self.title.write(f"{self.contents.vm_id}")
+        self.progress = self.parent.progress(self.contents.avg_cpu / 100, text=f"{int(self.contents.avg_cpu)}%")
+
+    def empty(self):
+        self.parent.empty()
+        self.title.empty()
+        self.progress.empty()
+
+    def update(self, contents: MachineOverviewCardContents):
+        self.contents = contents
+        self.title.write(f"{self.contents.vm_id}")
+        self.progress.progress(self.contents.avg_cpu / 100, text=f"{int(self.contents.avg_cpu)}%")
+
+
+class LiveMachineCount:
+    def __init__(self, parent_container, machine_type: str, num_machines: int):
+        self.parent = parent_container
+        self.machine_type = machine_type
+        self.num_machines = num_machines
+        self.machine_count_container = self.parent.empty()
+        # We need to set the background color of the container if we don't want to highlight it as a card
+        self.machine_count_container.markdown(
+            self._gen_markdown(machine_type, num_machines),
+            unsafe_allow_html=True,
+        )
+
+    def _gen_markdown(self, machine_type: str, num_machines: int):
+        return f"""
+            <div style='background-color: #1B2635'>
+                <h3 style='text-align: center;'>{num_machines}</h3>
+                <p style='text-align: center;'>{machine_type} Machines</p>
+                <br/>
+            <div>
+            """
+
+    def update(self, num_machines: int):
+        self.num_machines = num_machines
+        self.machine_count_container.markdown(
+            self._gen_markdown(self.machine_type, self.num_machines),
+            unsafe_allow_html=True,
+        )
+
+

--- a/rapidui/rapidui/library/config.py
+++ b/rapidui/rapidui/library/config.py
@@ -1,0 +1,11 @@
+from common.config.config import CentralityConfig
+from common.sdks.controlplane.handwritten.config import ControlPlaneSdkConfig
+from pydantic import Field
+
+
+class StreamlitUiConfig(CentralityConfig):
+    control_plane_sdk: ControlPlaneSdkConfig = Field(
+        default_factory=ControlPlaneSdkConfig
+    )
+    live_vm_interval_ms: int = 5000
+    cpu_metric_interval_ms: int = 200

--- a/rapidui/rapidui/library/constants.py
+++ b/rapidui/rapidui/library/constants.py
@@ -1,5 +1,5 @@
 
-TOKEN = "dev"
+TOKEN = "dev"  # TODO: Proper auth handling
 LOGO_SVG = (
     "https://armandmcqueenpublic.blob.core.windows.net/centrality-public/logo-blue.svg"
 )

--- a/rapidui/rapidui/library/constants.py
+++ b/rapidui/rapidui/library/constants.py
@@ -1,0 +1,5 @@
+
+TOKEN = "dev"
+LOGO_SVG = (
+    "https://armandmcqueenpublic.blob.core.windows.net/centrality-public/logo-blue.svg"
+)

--- a/rapidui/rapidui/library/cpu_view.py
+++ b/rapidui/rapidui/library/cpu_view.py
@@ -1,0 +1,24 @@
+
+from rapidui.library.flexbox import CardContents, BaseCard
+
+
+class CpuCardContents(CardContents):
+    def __init__(self, cpu_id: int, curr_cpu: float):
+        self.cpu_id = cpu_id
+        self.curr_cpu = curr_cpu
+
+
+class CpuCard(BaseCard):
+    def __init__(self, parent_container, contents: CpuCardContents):
+        self.container = parent_container
+        self.contents = contents
+        self.progress = self.container.progress(contents.curr_cpu / 100)
+
+    def empty(self):
+        self.container.empty()
+        self.progress.empty()
+
+    def update(self, contents: CpuCardContents):
+        self.contents = contents
+        self.progress.progress(contents.curr_cpu / 100)
+

--- a/rapidui/rapidui/library/cpu_view.py
+++ b/rapidui/rapidui/library/cpu_view.py
@@ -3,9 +3,8 @@ from rapidui.library.flexbox import CardContents, BaseCard
 
 
 class CpuCardContents(CardContents):
-    def __init__(self, cpu_id: int, curr_cpu: float):
-        self.cpu_id = cpu_id
-        self.curr_cpu = curr_cpu
+    cpu_id: int
+    curr_cpu: float
 
 
 class CpuCard(BaseCard):

--- a/rapidui/rapidui/library/flexbox.py
+++ b/rapidui/rapidui/library/flexbox.py
@@ -1,9 +1,12 @@
 import streamlit as st
+from pydantic import BaseModel
 from abc import ABC, abstractmethod
 
 
-class CardContents:
+class CardContents(BaseModel):
     pass
+
+
 
 
 class BaseCard(ABC):
@@ -67,5 +70,7 @@ class UniformFlexbox:
             )
             card = self.card_type(card_container, content)
             self.cards.append(card)
+
+
 
 

--- a/rapidui/rapidui/library/flexbox.py
+++ b/rapidui/rapidui/library/flexbox.py
@@ -1,0 +1,71 @@
+import streamlit as st
+from abc import ABC, abstractmethod
+
+
+class CardContents:
+    pass
+
+
+class BaseCard(ABC):
+    @abstractmethod
+    def __init__(self, parent_container, contents: CardContents):
+        """ This should create the card and set (render) its initial contents """
+        pass
+
+    @abstractmethod
+    def empty(self):
+        pass
+
+    @abstractmethod
+    def update(self, contents: CardContents):
+        pass
+
+
+class UniformFlexbox:
+    """A flexbox-like layout for displaying Cards that can be updated in real-time (i.e. without rerunning)"""
+
+    def __init__(self, num_cols: int, card_type: type[BaseCard], border: bool = True):
+        self.num_cols = num_cols
+        self.cols = st.columns(self.num_cols)
+        self.cards = []
+        self.card_type = card_type
+        self.border = border
+
+    def set_initial_cards(self, contents: list[CardContents]) -> None:
+        assert (
+            len(self.cards) == 0
+        ), "Can't set cards if there are already cards. Use update_cards instead."
+        for ind, content in enumerate(contents):
+            card_container = self.cols[ind % self.num_cols].container(
+                border=self.border
+            )
+            card = self.card_type(card_container, content)
+            self.cards.append(card)
+
+    def update_cards(self, contents: list[CardContents]) -> None:
+        """
+        Given a new set of measurements, update the cards to represent them. This will completely
+        rewrite the cards and add any new ones.
+
+        Note that if the number of cards decreases, there will be ghosts because we can't actually
+        truly delete a card - the border still shows up.
+        """
+        rewrites = contents[: len(self.cards)]
+        additions = contents[len(self.cards) :]
+        for ind, content in enumerate(rewrites):
+            self.cards[ind].update(content)
+
+        if len(rewrites) < len(self.cards):
+            # Any cards with an index >= len(rewrites) need to be emptied
+            for card in self.cards[len(rewrites) :]:
+                card.empty()
+
+        for ind, content in enumerate(additions):
+            real_ind = ind + len(rewrites)
+            card_container = self.cols[real_ind % self.num_cols].container(
+                border=self.border
+            )
+            card = self.card_type(card_container, content)
+            self.cards.append(card)
+
+

--- a/rapidui/rapidui/library/utils.py
+++ b/rapidui/rapidui/library/utils.py
@@ -1,0 +1,11 @@
+from rapidui.library.config import StreamlitUiConfig
+import time
+
+
+def calculate_epoch(interval_ms: int) -> int:
+    current_sec = int(time.time() * 1000)
+    return int(current_sec / interval_ms)
+
+
+def load_config() -> StreamlitUiConfig:
+    return StreamlitUiConfig.from_envvar()

--- a/rapidui/rapidui/library/utils.py
+++ b/rapidui/rapidui/library/utils.py
@@ -3,6 +3,10 @@ import time
 
 
 def calculate_epoch(interval_ms: int) -> int:
+    # Given the current time in seconds, calculate the epoch in milliseconds. This is used in combination with
+    # st.cache_data to refresh the cache every interval_ms milliseconds. This works because st.cache_data
+    # caches based on argument values, so if we use the epoch as an argument to the cached function, it will
+    # use the cache until the epoch updates.
     current_sec = int(time.time() * 1000)
     return int(current_sec / interval_ms)
 

--- a/rapidui/rapidui/pages/1_Cluster.py
+++ b/rapidui/rapidui/pages/1_Cluster.py
@@ -3,16 +3,16 @@ import time
 import streamlit as st
 from common.sdks.controlplane.handwritten.sdk import ControlPlaneSdk
 
-from rapidui.lib.flexbox import UniformFlexbox
-from rapidui.lib.cluster_view import (
+from rapidui.library.flexbox import UniformFlexbox
+from rapidui.library.cluster_view import (
     MachineOverviewCard,
     MachineOverviewCardContents,
     LiveMachineCount,
 )
 from rapidui.header import header
-from rapidui.lib.utils import load_config, calculate_epoch
-from rapidui.lib.config import StreamlitUiConfig
-from rapidui.lib.constants import TOKEN
+from rapidui.library.utils import load_config, calculate_epoch
+from rapidui.library.config import StreamlitUiConfig
+from rapidui.library.constants import TOKEN
 
 
 # Use caching with epochs to only refresh data at some interval

--- a/rapidui/rapidui/pages/1_Cluster.py
+++ b/rapidui/rapidui/pages/1_Cluster.py
@@ -44,6 +44,8 @@ def gen_data(
         _sdk=control_plane_sdk,
         epoch=calculate_epoch(interval_ms=config.live_vm_interval_ms),
     )
+    if len(live_vms) == 0:
+        return [], []
     cpu_metrics = get_cpu_metrics(
         _sdk=control_plane_sdk,
         live_vms=live_vms,

--- a/rapidui/rapidui/pages/2_Machine_-_CPU.py
+++ b/rapidui/rapidui/pages/2_Machine_-_CPU.py
@@ -1,12 +1,12 @@
 import time
 import streamlit as st
 
-from rapidui.lib.flexbox import UniformFlexbox
+from rapidui.library.flexbox import UniformFlexbox
 from rapidui.header import header
-from rapidui.lib.utils import load_config, calculate_epoch
-from rapidui.lib.constants import TOKEN
+from rapidui.library.utils import load_config, calculate_epoch
+from rapidui.library.constants import TOKEN
 from common.sdks.controlplane.handwritten.sdk import ControlPlaneSdk
-from rapidui.lib.cpu_view import CpuCardContents, CpuCard
+from rapidui.library.cpu_view import CpuCardContents, CpuCard
 
 
 @st.cache_data

--- a/tests/configs/fly/rapidui.yaml
+++ b/tests/configs/fly/rapidui.yaml
@@ -1,0 +1,4 @@
+control_plane_sdk:
+  host: centrality-dev.fly.dev
+  https: true
+  port: 8000

--- a/tests/configs/fly/vmagent-auto.yaml
+++ b/tests/configs/fly/vmagent-auto.yaml
@@ -1,0 +1,14 @@
+#vm_id: test-machine
+controlplane_sdk:
+  host: centrality-dev.fly.dev
+  https: true
+  port: 8000
+#metrics:
+#  cpu:
+#    use_fake: true
+#    fake:
+#      algorithm: linear_synced  # linear_synced | random
+#      jitter: true
+#      jitter_factor: 0.4
+#      num_vals: 16
+#      period: 10

--- a/tests/configs/fly/vmagent-auto.yaml
+++ b/tests/configs/fly/vmagent-auto.yaml
@@ -1,14 +1,13 @@
-#vm_id: test-machine
 controlplane_sdk:
   host: centrality-dev.fly.dev
   https: true
   port: 8000
-#metrics:
-#  cpu:
-#    use_fake: true
-#    fake:
-#      algorithm: linear_synced  # linear_synced | random
-#      jitter: true
-#      jitter_factor: 0.4
-#      num_vals: 16
-#      period: 10
+metrics:
+  cpu:
+    use_fake: true
+    fake:
+      algorithm: linear_synced  # linear_synced | random
+      jitter: true
+      jitter_factor: 0.4
+      num_vals: 16
+      period: 10

--- a/tests/configs/fly/vmagent-local.yaml
+++ b/tests/configs/fly/vmagent-local.yaml
@@ -1,4 +1,4 @@
-vm_id: test-machine
+vm_id: test-machine-local
 controlplane_sdk:
   host: centrality-dev.fly.dev
   https: true

--- a/tests/configs/fly/vmagent.yaml
+++ b/tests/configs/fly/vmagent.yaml
@@ -1,0 +1,14 @@
+vm_id: test-machine
+controlplane_sdk:
+  host: centrality-dev.fly.dev
+  https: true
+  port: 8000
+metrics:
+  cpu:
+    use_fake: true
+    fake:
+      algorithm: linear_synced  # linear_synced | random
+      jitter: true
+      jitter_factor: 0.4
+      num_vals: 16
+      period: 10


### PR DESCRIPTION
Add rapidui to the Fly deployment. Add a new Fly application that runs a small number of agents constantly.

This exposed a major bug where the rapidui lib code wasn't in github because that name is git/docker ignored. Fixed that in this PR by renaming it to library