### PR TITLE
Add preview deployment URL as PR comment

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -33,8 +33,7 @@ jobs:
 
       - name: Deploy Preview
         id: deploy-preview
-#        run: python deploy/deploy/aws/instances.py launch m7g.medium --checkout ${{ github.sha }} --idempotency-token ${{ github.ref_name }}
-        run: echo "testurl-3:8501" > /tmp/preview-url
+        run: python deploy/deploy/aws/instances.py launch m7g.medium --checkout ${{ github.sha }} --idempotency-token ${{ github.ref_name }}
 
       - name: Save Preview URL
         id: preview-url
@@ -56,22 +55,13 @@ jobs:
         run: |
           export PR_NUMBER=$(gh pr view --json number -q .number || echo "" )
           
-          echo "2 start"
-          env
-          
-          echo "end 2"
-          
           # Search for an existing comment with the unique identifier
           COMMENT_ID=$(gh api repos/${REPO}/issues/${PR_NUMBER}/comments --jq '.[] | select(.body | contains("'"$COMMENT_IDENTIFIER"'")) | .id')
-          echo "3"
-          echo $COMMENT_ID
           if [ -z "$COMMENT_ID" ]; then
             # Create new comment
-            echo "4"
             gh pr comment $PR_NUMBER --body "$COMMENT_IDENTIFIER $PREVIEW_URL" --repo $REPO
           else
             # Update existing comment
-            echo "4-2"
             gh api repos/$REPO/issues/comments/$COMMENT_ID --method PATCH --field body="$COMMENT_IDENTIFIER $PREVIEW_URL"
           fi
           

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -33,7 +33,8 @@ jobs:
 
       - name: Deploy Preview
         id: deploy-preview
-        run: python deploy/deploy/aws/instances.py launch m7g.medium --checkout ${{ github.sha }} --idempotency-token ${{ github.ref_name }}
+#        run: python deploy/deploy/aws/instances.py launch m7g.medium --checkout ${{ github.sha }} --idempotency-token ${{ github.ref_name }}
+        run: echo "testurl:8501" > /preview-url
 
       - name: Save Preview URL
         id: preview-url

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Deploy Preview
         id: deploy-preview
 #        run: python deploy/deploy/aws/instances.py launch m7g.medium --checkout ${{ github.sha }} --idempotency-token ${{ github.ref_name }}
-        run: echo "testurl-2:8501" > /tmp/preview-url
+        run: echo "testurl-3:8501" > /tmp/preview-url
 
       - name: Save Preview URL
         id: preview-url

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Install dependencies including dev
-        run: make install-dev
+#      - name: Install dependencies including dev
+#        run: make install-dev
 
       - name: Setup SSH key
         run: |
@@ -34,7 +34,7 @@ jobs:
       - name: Deploy Preview
         id: deploy-preview
 #        run: python deploy/deploy/aws/instances.py launch m7g.medium --checkout ${{ github.sha }} --idempotency-token ${{ github.ref_name }}
-        run: echo "testurl:8501" > /preview-url
+        run: echo "testurl:8501" > /tmp/preview-url
 
       - name: Save Preview URL
         id: preview-url

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -61,10 +61,6 @@ jobs:
           env
           
           export PR_NUMBER=$(gh pr view --json number -q .number || echo "" )
-#          export REPO=${{ github.repository }}
-#          export PREVIEW_URL=${{ steps.preview-url.outputs.PREVIEW_URL }}
-#          export COMMENT_IDENTIFIER="🔎 Preview Deployment:"
-#          export GH_TOKEN=${{ github.token }}
           
           echo "2"
           env

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -35,12 +35,20 @@ jobs:
         id: deploy-preview
         run: python deploy/deploy/aws/instances.py launch m7g.medium --checkout ${{ github.sha }} --idempotency-token ${{ github.ref_name }}
 
+      - name: Save Preview URL
+        id: preview-url
+        run: |
+          URL=$(cat /tmp/preview-url)
+          echo ${URL}
+          ENVSET=PREVIEW_URL=${url}
+          echo ENVSET >> $GITHUB_OUTPUT
+
       - name: Comment Preview URL
         # Note: This is all AI generated
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-          PREVIEW_URL: ${{ steps.deploy-preview.outputs.preview_url }}
+          PREVIEW_URL: ${{ steps.preview-url.outputs.PREVIEW_URL }}
           COMMENT_IDENTIFIER: "Preview Deployment:"
           GH_TOKEN: ${{ github.token }}
 
@@ -51,7 +59,7 @@ jobs:
           
           export PR_NUMBER=${{ github.event.pull_request.number }}
           export REPO=${{ github.repository }}
-          export PREVIEW_URL=${{ steps.deploy-preview.outputs.preview_url }}
+          export PREVIEW_URL=${{ steps.preview-url.outputs.PREVIEW_URL }}
           export COMMENT_IDENTIFIER="Preview Deployment:"
           export GH_TOKEN=${{ github.token }}
           

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           PREVIEW_URL: ${{ steps.preview-url.outputs.PREVIEW_URL }}
-          COMMENT_IDENTIFIER: "🔎 Preview Deployment:"
+          COMMENT_IDENTIFIER: "Preview Deployment:"
           GH_TOKEN: ${{ github.token }}
 
         run: |
@@ -61,7 +61,6 @@ jobs:
           
           echo "end 2"
           # Search for an existing comment with the unique identifier
-          COMMENT_ID=$(gh pr view $PR_NUMBER --repo $REPO --json comments --jq '.comments[] | select(.body | contains("'"$COMMENT_IDENTIFIER"'")) | .id')
           COMMENT_ID=$(gh api repos/${REPO}/issues/${PR_NUMBER}/comments --jq '.[] | select(.body | contains("'"$COMMENT_IDENTIFIER"'")) | .id')
           echo "3"
           echo $COMMENT_ID

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           export PR_NUMBER=$(gh pr view --json number -q .number || echo "" )
           
-          echo "2"
+          echo "2 start"
           env
           
           echo "end 2"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -64,7 +64,7 @@ jobs:
           export PR_NUMBER=$(gh pr view --json number -q .number || echo "" )
           export REPO=${{ github.repository }}
           export PREVIEW_URL=${{ steps.preview-url.outputs.PREVIEW_URL }}
-          export COMMENT_IDENTIFIER="Preview Deployment:"
+          COMMENT_IDENTIFIER: "🔎 Preview Deployment:"
           export GH_TOKEN=${{ github.token }}
           
           echo "2"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -32,4 +32,23 @@ jobs:
           cat ~/.ssh/config
 
       - name: Deploy Preview
+        id: deploy-preview
         run: python deploy/deploy/aws/instances.py launch m7g.medium --checkout ${{ github.sha }} --idempotency-token ${{ github.ref_name }}
+
+      - name: Comment Preview URL
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          REPO=${{ github.repository }}
+          PREVIEW_URL=${{ steps.deploy-preview.outputs.preview_url }}
+          COMMENT_IDENTIFIER="Preview Deployment:"
+
+          # Search for an existing comment with the unique identifier
+          COMMENT_ID=$(gh pr view $PR_NUMBER --repo $REPO --json comments --jq '.comments[] | select(.body | contains("'"$COMMENT_IDENTIFIER"'")) | .id')
+
+          if [ -z "$COMMENT_ID" ]; then
+            # Create new comment
+            gh pr comment $PR_NUMBER --body "$COMMENT_IDENTIFIER $PREVIEW_URL" --repo $REPO
+          else
+            # Update existing comment
+            gh api repos/$REPO/issues/comments/$COMMENT_ID --method PATCH --field body="$COMMENT_IDENTIFIER $PREVIEW_URL"
+          fi

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Deploy Preview
         id: deploy-preview
 #        run: python deploy/deploy/aws/instances.py launch m7g.medium --checkout ${{ github.sha }} --idempotency-token ${{ github.ref_name }}
-        run: echo "testurl:8501" > /tmp/preview-url
+        run: echo "testurl-2:8501" > /tmp/preview-url
 
       - name: Save Preview URL
         id: preview-url

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           URL=$(cat /tmp/preview-url)
           echo ${URL}
-          ENVSET=PREVIEW_URL=${url}
+          ENVSET=PREVIEW_URL=${URL}
           echo ${ENVSET}
           echo "${ENVSET}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -64,7 +64,7 @@ jobs:
           export PR_NUMBER=$(gh pr view --json number -q .number || echo "" )
           export REPO=${{ github.repository }}
           export PREVIEW_URL=${{ steps.preview-url.outputs.PREVIEW_URL }}
-          COMMENT_IDENTIFIER: "🔎 Preview Deployment:"
+          COMMENT_IDENTIFIER="🔎 Preview Deployment:"
           export GH_TOKEN=${{ github.token }}
           
           echo "2"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -45,6 +45,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
         run: |
+          env
+          
           # Search for an existing comment with the unique identifier
           COMMENT_ID=$(gh pr view $PR_NUMBER --repo $REPO --json comments --jq '.comments[] | select(.body | contains("'"$COMMENT_IDENTIFIER"'")) | .id')
 

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -41,7 +41,8 @@ jobs:
           URL=$(cat /tmp/preview-url)
           echo ${URL}
           ENVSET=PREVIEW_URL=${url}
-          echo ${ENVSET} >> $GITHUB_OUTPUT
+          echo ${ENVSET}
+          echo "${ENVSET}" >> "$GITHUB_OUTPUT"
 
       - name: Comment Preview URL
         # Note: This is all AI generated
@@ -49,15 +50,18 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           PREVIEW_URL: ${{ steps.preview-url.outputs.PREVIEW_URL }}
-          COMMENT_IDENTIFIER: "Preview Deployment:"
+          COMMENT_IDENTIFIER: "🔎 Preview Deployment:"
           GH_TOKEN: ${{ github.token }}
 
         run: |
+          echo "0"
+          cat $GITHUB_EVENT_PATH
+          
           echo "1"
           env
           
           
-          export PR_NUMBER=${{ github.event.pull_request.number }}
+          export PR_NUMBER=$(gh pr view --json number -q .number || echo "" )
           export REPO=${{ github.repository }}
           export PREVIEW_URL=${{ steps.preview-url.outputs.PREVIEW_URL }}
           export COMMENT_IDENTIFIER="Preview Deployment:"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -62,7 +62,9 @@ jobs:
           echo "end 2"
           # Search for an existing comment with the unique identifier
           COMMENT_ID=$(gh pr view $PR_NUMBER --repo $REPO --json comments --jq '.comments[] | select(.body | contains("'"$COMMENT_IDENTIFIER"'")) | .id')
+          COMMENT_ID=$(gh api repos/${REPO}/issues/${PR_NUMBER}/comments --jq '.[] | select(.body | contains("$COMMENT_IDENTIFIER")) | .id')
           echo "3"
+          echo $COMMENT_ID
           if [ -z "$COMMENT_ID" ]; then
             # Create new comment
             echo "4"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Comment Preview URL
         # Note: This is all AI generated
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           PREVIEW_URL: ${{ steps.preview-url.outputs.PREVIEW_URL }}
           COMMENT_IDENTIFIER: "🔎 Preview Deployment:"
@@ -61,23 +60,25 @@ jobs:
           echo "1"
           env
           
-          
           export PR_NUMBER=$(gh pr view --json number -q .number || echo "" )
-          export REPO=${{ github.repository }}
-          export PREVIEW_URL=${{ steps.preview-url.outputs.PREVIEW_URL }}
-          COMMENT_IDENTIFIER="🔎 Preview Deployment:"
-          export GH_TOKEN=${{ github.token }}
+#          export REPO=${{ github.repository }}
+#          export PREVIEW_URL=${{ steps.preview-url.outputs.PREVIEW_URL }}
+#          export COMMENT_IDENTIFIER="🔎 Preview Deployment:"
+#          export GH_TOKEN=${{ github.token }}
           
           echo "2"
           env
           
+          echo "end 2"
           # Search for an existing comment with the unique identifier
           COMMENT_ID=$(gh pr view $PR_NUMBER --repo $REPO --json comments --jq '.comments[] | select(.body | contains("'"$COMMENT_IDENTIFIER"'")) | .id')
-
+          echo "3"
           if [ -z "$COMMENT_ID" ]; then
             # Create new comment
+            echo "4"
             gh pr comment $PR_NUMBER --body "$COMMENT_IDENTIFIER $PREVIEW_URL" --repo $REPO
           else
             # Update existing comment
+            echo "4-2"
             gh api repos/$REPO/issues/comments/$COMMENT_ID --method PATCH --field body="$COMMENT_IDENTIFIER $PREVIEW_URL"
           fi

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -41,7 +41,7 @@ jobs:
           URL=$(cat /tmp/preview-url)
           echo ${URL}
           ENVSET=PREVIEW_URL=${url}
-          echo ENVSET >> $GITHUB_OUTPUT
+          echo ${ENVSET} >> $GITHUB_OUTPUT
 
       - name: Comment Preview URL
         # Note: This is all AI generated

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -54,12 +54,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
         run: |
-          echo "0"
-          cat $GITHUB_EVENT_PATH
-          
-          echo "1"
-          env
-          
           export PR_NUMBER=$(gh pr view --json number -q .number || echo "" )
           
           echo "2"
@@ -78,3 +72,4 @@ jobs:
             echo "4-2"
             gh api repos/$REPO/issues/comments/$COMMENT_ID --method PATCH --field body="$COMMENT_IDENTIFIER $PREVIEW_URL"
           fi
+          

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -62,7 +62,7 @@ jobs:
           echo "end 2"
           # Search for an existing comment with the unique identifier
           COMMENT_ID=$(gh pr view $PR_NUMBER --repo $REPO --json comments --jq '.comments[] | select(.body | contains("'"$COMMENT_IDENTIFIER"'")) | .id')
-          COMMENT_ID=$(gh api repos/${REPO}/issues/${PR_NUMBER}/comments --jq '.[] | select(.body | contains("$COMMENT_IDENTIFIER")) | .id')
+          COMMENT_ID=$(gh api repos/${REPO}/issues/${PR_NUMBER}/comments --jq '.[] | select(.body | contains("'"$COMMENT_IDENTIFIER"'")) | .id')
           echo "3"
           echo $COMMENT_ID
           if [ -z "$COMMENT_ID" ]; then

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -60,6 +60,7 @@ jobs:
           env
           
           echo "end 2"
+          
           # Search for an existing comment with the unique identifier
           COMMENT_ID=$(gh api repos/${REPO}/issues/${PR_NUMBER}/comments --jq '.[] | select(.body | contains("'"$COMMENT_IDENTIFIER"'")) | .id')
           echo "3"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -36,12 +36,15 @@ jobs:
         run: python deploy/deploy/aws/instances.py launch m7g.medium --checkout ${{ github.sha }} --idempotency-token ${{ github.ref_name }}
 
       - name: Comment Preview URL
-        run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          REPO=${{ github.repository }}
-          PREVIEW_URL=${{ steps.deploy-preview.outputs.preview_url }}
-          COMMENT_IDENTIFIER="Preview Deployment:"
+        # Note: This is all AI generated
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          PREVIEW_URL: ${{ steps.deploy-preview.outputs.preview_url }}
+          COMMENT_IDENTIFIER: "Preview Deployment:"
+          GH_TOKEN: ${{ github.token }}
 
+        run: |
           # Search for an existing comment with the unique identifier
           COMMENT_ID=$(gh pr view $PR_NUMBER --repo $REPO --json comments --jq '.comments[] | select(.body | contains("'"$COMMENT_IDENTIFIER"'")) | .id')
 

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -45,6 +45,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
         run: |
+          echo "1"
+          env
+          
+          
+          export PR_NUMBER=${{ github.event.pull_request.number }}
+          export REPO=${{ github.repository }}
+          export PREVIEW_URL=${{ steps.deploy-preview.outputs.preview_url }}
+          export COMMENT_IDENTIFIER="Preview Deployment:"
+          export GH_TOKEN=${{ github.token }}
+          
+          echo "2"
           env
           
           # Search for an existing comment with the unique identifier

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-#      - name: Install dependencies including dev
-#        run: make install-dev
+      - name: Install dependencies including dev
+        run: make install-dev
 
       - name: Setup SSH key
         run: |

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -13,6 +13,8 @@ The instances will automatically shut down after a certain amount of time, which
 `--ttl-secs` flag. Note that this might not work correctly if the cloud-init script fails, but that should
 only hopefully happen during development of this code.
 
+
+
 ### Getting started
 
 Empty `config.yaml`, and set these fields with real values:
@@ -47,6 +49,8 @@ We keep a manual mapping between instance types and AMI (because there is an x64
 different ARM Ubuntu AMI). If you want to use a different instance type, you need to add it to the
 `INSTANCE_TO_AMI` dict in `constants.py`.
 
+Note: the preview URL will be written to `/tmp/preview-url` if `--wait` is true. This is for 
+github actions to pick up.
 
 ### Cleanup
 
@@ -55,6 +59,8 @@ To remove all resources created by this repo:
 python instances.py delete
 python security_groups.py delete
 python iam.py delete
+
+rm /tmp/preview-url
 ```
 
 

--- a/deploy/deploy/aws/instances.py
+++ b/deploy/deploy/aws/instances.py
@@ -211,7 +211,11 @@ def _launch(
                     print(
                         f"[green]Healthcheck passed after {round(time.time() - start_time, 2)} seconds!"
                     )
-                    print(f"UI available at: http://{instance.public_dns_name}:8501")
+                    url = f"http://{instance.public_dns_name}:8501"
+
+                    # Make the URL available to GitHub Actions
+                    print(f"::set-output name=preview_url::{url}")
+                    print(f"UI available at: {url}")
                     break
 
             except requests.exceptions.ConnectionError:

--- a/deploy/deploy/aws/instances.py
+++ b/deploy/deploy/aws/instances.py
@@ -12,6 +12,8 @@ from rich.console import Console
 import subprocess
 import os
 
+PREVIEW_URL_FILE = Path("/tmp/preview-url")
+
 CONFIG_FILE_PATH = Path(__file__).parent / "config.yaml"
 if constants.CONFIG_PATH_OVERRIDE_ENVVAR in os.environ:
     CONFIG_FILE_PATH = Path(os.environ[constants.CONFIG_PATH_OVERRIDE_ENVVAR])
@@ -214,7 +216,9 @@ def _launch(
                     url = f"http://{instance.public_dns_name}:8501"
 
                     # Make the URL available to GitHub Actions
-                    print(f"::set-output name=preview_url::{url}")
+                    with PREVIEW_URL_FILE.open("w+") as f:
+                        f.write(url)
+
                     print(f"UI available at: {url}")
                     break
 


### PR DESCRIPTION
Deploying a preview instance now saves the preview url to `/tmp/preview-url`. Added an extra step to preview deployment that adds a PR comment with the preview URL. It will create a new comment if no URL comment exists or will overwrite an existing comment if it does. It checks whether a comment exists already by matching a unique string