### PR TITLE
Auto reset DB before every datastore test

### DIFF
--- a/.idea/centrality.iml
+++ b/.idea/centrality.iml
@@ -32,6 +32,8 @@
       <excludeFolder url="file://$MODULE_DIR$/scripts/.ruff_cache/0.1.7" />
       <excludeFolder url="file://$MODULE_DIR$/tests/.pytest_cache" />
       <excludeFolder url="file://$MODULE_DIR$/tests/.ruff_cache/0.1.7" />
+      <excludeFolder url="file://$MODULE_DIR$/tests/datastore/.pytest_cache" />
+      <excludeFolder url="file://$MODULE_DIR$/tests/e2e/.pytest_cache" />
     </content>
     <orderEntry type="jdk" jdkName="Python 3.11 (centrality)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/tests/datastore/conftest.py
+++ b/tests/datastore/conftest.py
@@ -33,3 +33,10 @@ def datastore():
         print("✓ DB setup")
 
         yield config, client
+
+
+@pytest.fixture(autouse=True)
+def setup_code(datastore: tuple[DatastoreConfig, DatastoreClient]):
+    """Make sure that every test starts with a clean DB"""
+    config, client = datastore
+    client.reset_db()

--- a/tests/datastore/test_datastore_client.py
+++ b/tests/datastore/test_datastore_client.py
@@ -4,10 +4,11 @@ from controlplane.datastore.client import DatastoreClient
 from common import constants
 import datetime
 
+VM_ID = "testvm"
+
 
 def test_tokens(datastore: tuple[DatastoreConfig, DatastoreClient]):
     config, client = datastore
-    client.reset_db()
 
     # Validate that create a new token works
     user_token = client.new_token()
@@ -37,9 +38,7 @@ def test_tokens(datastore: tuple[DatastoreConfig, DatastoreClient]):
 
 
 def test_cpu_measurements(datastore: tuple[DatastoreConfig, DatastoreClient]):
-    VM_ID = "examplevm"
     config, client = datastore
-    client.reset_db()
 
     now = datetime.datetime.now(datetime.timezone.utc)
     # Create a timestamp for each of the last 5 seconds


### PR DESCRIPTION
Automatically reset the DB before every datastore test so that tests are easier to write/require less repetition