### PR TITLE
Fix preview deployment

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Check out repository code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install dependencies including dev
         run: make install-dev
@@ -37,7 +39,7 @@ jobs:
       - name: Deploy Preview
         id: deploy-preview
         run: |
-          python deploy/deploy/aws/instances.py launch m7g.medium --checkout ${{ github.sha }} --idempotency-token ${{ github.ref_name }}
+          python deploy/deploy/aws/instances.py launch m7g.medium --checkout ${{ github.event.pull_request.head.sha }} --idempotency-token ${{ github.head_ref }}
 
       - name: Save Preview URL
         id: preview-url


### PR DESCRIPTION
Changing from on push to on pull_request has introduced some bug. This PR makes sure that the preview is using the most recent commit for the PR branch. It also improves the EC2 instance name to be the branch instead of `23/merge`, which is cosmetic as the previous approach functioned fine.