### PR TITLE
Reduce metric frequency from 10hz to 5hz

### DIFF
--- a/common/common/constants.py
+++ b/common/common/constants.py
@@ -70,7 +70,7 @@ VM_AGENT_REST_CONFIG_ENVVAR = "CENTRALITY_VM_AGENT_REST_CONFIG"
 
 # TODO: Make metric speed configurable
 # Enable this to make metrics slower for testing other functionality
-METRIC_SPEED = 0.1
+METRIC_SPEED = 0.2
 # METRIC_SPEED = 10
 
 VM_AGENT_METRIC_CPU_INTERVAL_SECS = METRIC_SPEED

--- a/common/common/constants.py
+++ b/common/common/constants.py
@@ -71,7 +71,6 @@ VM_AGENT_REST_CONFIG_ENVVAR = "CENTRALITY_VM_AGENT_REST_CONFIG"
 # TODO: Make metric speed configurable
 # Enable this to make metrics slower for testing other functionality
 METRIC_SPEED = 0.2
-# METRIC_SPEED = 10
 
 VM_AGENT_METRIC_CPU_INTERVAL_SECS = METRIC_SPEED
 VM_AGENT_METRIC_DISK_INTERVAL_SECS = METRIC_SPEED


### PR DESCRIPTION
10hz is consuming a lot of CPU and the user experience isn't noticeably better than 5 hz. This is a temporary improvement - the underlying problem probably requires batching.