### PR TITLE
Add Machine Info page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update  \
     gcc \
     sudo \
     make \
-    git
+    git \
+    dmidecode
 
 # Install pip
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11

--- a/common/common/constants.py
+++ b/common/common/constants.py
@@ -1,3 +1,4 @@
+import os
 #####################################################################
 # Endpoints                                                         #
 #####################################################################
@@ -74,9 +75,9 @@ CONTROL_PLANE_SDK_DEV_TOKEN = "dev"
 MACHINE_AGENT_REST_CONFIG_ENVVAR = "CENTRALITY_MACHINE_AGENT_REST_CONFIG"
 
 
-# TODO: Make metric speed configurable
-# Enable this to make metrics slower for testing other functionality
 METRIC_SPEED = 0.25
+if os.environ.get("CENTRALITY_DEVELOPMENT_METRIC_SPEED"):
+    METRIC_SPEED = float(os.environ.get("CENTRALITY_DEVELOPMENT_METRIC_SPEED"))
 
 MACHINE_AGENT_METRIC_CPU_INTERVAL_SECS = METRIC_SPEED
 MACHINE_AGENT_METRIC_DISK_INTERVAL_SECS = METRIC_SPEED

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,7 @@ services:
       replicas: 2
     environment:
       - PYTHONUNBUFFERED=1
+      - CENTRALITY_DEVELOPMENT_METRIC_SPEED
     working_dir: /centrality
     command: "python3.11 machineagent/machineagent/cli.py launch -f tests/configs/dockercompose/machineagent-auto.yaml --machine-id auto"
     depends_on:
@@ -16,6 +17,7 @@ services:
     build: .
     environment:
       - PYTHONUNBUFFERED=1
+      - CENTRALITY_DEVELOPMENT_METRIC_SPEED
     working_dir: /centrality
     command: "python3.11 machineagent/machineagent/cli.py launch -f tests/configs/dockercompose/machineagent-real.yaml"
     depends_on:
@@ -25,6 +27,7 @@ services:
     build: .
     environment:
       - PYTHONUNBUFFERED=1
+      - CENTRALITY_DEVELOPMENT_METRIC_SPEED
     working_dir: /centrality
     command: "python3.11 machineagent/machineagent/cli.py launch -f tests/configs/dockercompose/machineagent-fake.yaml"
     depends_on:
@@ -34,6 +37,7 @@ services:
     build: .
     environment:
       - PYTHONUNBUFFERED=1
+      - CENTRALITY_DEVELOPMENT_METRIC_SPEED
     working_dir: /centrality
     command: "python3.11 machineagent/machineagent/cli.py launch -f tests/configs/dockercompose/machineagent-gpus.yaml"
     depends_on:
@@ -45,6 +49,7 @@ services:
       - "0.0.0.0:8000:8000"
     environment:
       - PYTHONUNBUFFERED=1
+      - CENTRALITY_DEVELOPMENT_METRIC_SPEED
     working_dir: /centrality/controlplane
     command: "python3.11 controlplane/cli.py launch --postgres-host postgres"
     depends_on:

--- a/controlplane/controlplane/rest/api.py
+++ b/controlplane/controlplane/rest/api.py
@@ -243,7 +243,7 @@ def get_cpu_metrics(
     to_ts: Optional[datetime.datetime] = None,
 ) -> list[CpuMeasurement]:
     """
-    Get cpu metrics for certain MACHINEs between from_ts to to_ts, inclusive.
+    Get cpu metrics for certain machines between from_ts to to_ts, inclusive.
     :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).
     :param from_ts: Start time filter, inclusive. Optional.
     :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an
@@ -291,7 +291,7 @@ def get_disk_iops_metrics(
     to_ts: Optional[datetime.datetime] = None,
 ) -> list[DiskIopsMeasurement]:
     """
-    Get disk_iops metrics for certain MACHINEs between from_ts to to_ts, inclusive.
+    Get disk_iops metrics for certain machines between from_ts to to_ts, inclusive.
     :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).
     :param from_ts: Start time filter, inclusive. Optional.
     :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an
@@ -341,7 +341,7 @@ def get_disk_usage_metrics(
     to_ts: Optional[datetime.datetime] = None,
 ) -> list[DiskUsageMeasurement]:
     """
-    Get disk_usage metrics for certain MACHINEs between from_ts to to_ts, inclusive.
+    Get disk_usage metrics for certain machines between from_ts to to_ts, inclusive.
     :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).
     :param from_ts: Start time filter, inclusive. Optional.
     :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an
@@ -393,7 +393,7 @@ def get_disk_throughput_metrics(
     to_ts: Optional[datetime.datetime] = None,
 ) -> list[DiskThroughputMeasurement]:
     """
-    Get disk_throughput metrics for certain MACHINEs between from_ts to to_ts, inclusive.
+    Get disk_throughput metrics for certain machines between from_ts to to_ts, inclusive.
     :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).
     :param from_ts: Start time filter, inclusive. Optional.
     :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an
@@ -445,7 +445,7 @@ def get_gpu_memory_metrics(
     to_ts: Optional[datetime.datetime] = None,
 ) -> list[GpuMemoryMeasurement]:
     """
-    Get gpu_memory metrics for certain MACHINEs between from_ts to to_ts, inclusive.
+    Get gpu_memory metrics for certain machines between from_ts to to_ts, inclusive.
     :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).
     :param from_ts: Start time filter, inclusive. Optional.
     :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an
@@ -497,7 +497,7 @@ def get_gpu_utilization_metrics(
     to_ts: Optional[datetime.datetime] = None,
 ) -> list[GpuUtilizationMeasurement]:
     """
-    Get gpu_utilization metrics for certain MACHINEs between from_ts to to_ts, inclusive.
+    Get gpu_utilization metrics for certain machines between from_ts to to_ts, inclusive.
     :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).
     :param from_ts: Start time filter, inclusive. Optional.
     :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an
@@ -549,7 +549,7 @@ def get_memory_metrics(
     to_ts: Optional[datetime.datetime] = None,
 ) -> list[MemoryMeasurement]:
     """
-    Get memory metrics for certain MACHINEs between from_ts to to_ts, inclusive.
+    Get memory metrics for certain machines between from_ts to to_ts, inclusive.
     :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).
     :param from_ts: Start time filter, inclusive. Optional.
     :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an
@@ -597,7 +597,7 @@ def get_network_throughput_metrics(
     to_ts: Optional[datetime.datetime] = None,
 ) -> list[NetworkThroughputMeasurement]:
     """
-    Get network_throughput metrics for certain MACHINEs between from_ts to to_ts, inclusive.
+    Get network_throughput metrics for certain machines between from_ts to to_ts, inclusive.
     :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).
     :param from_ts: Start time filter, inclusive. Optional.
     :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an
@@ -650,7 +650,7 @@ def get_nvidia_smi_metrics(
     to_ts: Optional[datetime.datetime] = None,
 ) -> list[NvidiaSmiMeasurement]:
     """
-    Get nvidia_smi metrics for certain MACHINEs between from_ts to to_ts, inclusive.
+    Get nvidia_smi metrics for certain machines between from_ts to to_ts, inclusive.
     :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).
     :param from_ts: Start time filter, inclusive. Optional.
     :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an

--- a/controlplane/openapi.json
+++ b/controlplane/openapi.json
@@ -315,7 +315,7 @@
           "data"
         ],
         "summary": "Get Cpu Metrics",
-        "description": "Get cpu metrics for certain MACHINEs between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of CpuMeasurement objects",
+        "description": "Get cpu metrics for certain machines between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of CpuMeasurement objects",
         "operationId": "get_cpu_metrics",
         "security": [
           {
@@ -504,7 +504,7 @@
           "data"
         ],
         "summary": "Get Disk Iops Metrics",
-        "description": "Get disk_iops metrics for certain MACHINEs between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of DiskIopsMeasurement objects",
+        "description": "Get disk_iops metrics for certain machines between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of DiskIopsMeasurement objects",
         "operationId": "get_disk_iops_metrics",
         "security": [
           {
@@ -693,7 +693,7 @@
           "data"
         ],
         "summary": "Get Disk Usage Metrics",
-        "description": "Get disk_usage metrics for certain MACHINEs between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of DiskUsageMeasurement objects",
+        "description": "Get disk_usage metrics for certain machines between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of DiskUsageMeasurement objects",
         "operationId": "get_disk_usage_metrics",
         "security": [
           {
@@ -882,7 +882,7 @@
           "data"
         ],
         "summary": "Get Disk Throughput Metrics",
-        "description": "Get disk_throughput metrics for certain MACHINEs between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of DiskThroughputMeasurement objects",
+        "description": "Get disk_throughput metrics for certain machines between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of DiskThroughputMeasurement objects",
         "operationId": "get_disk_throughput_metrics",
         "security": [
           {
@@ -1071,7 +1071,7 @@
           "data"
         ],
         "summary": "Get Gpu Memory Metrics",
-        "description": "Get gpu_memory metrics for certain MACHINEs between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of GpuMemoryMeasurement objects",
+        "description": "Get gpu_memory metrics for certain machines between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of GpuMemoryMeasurement objects",
         "operationId": "get_gpu_memory_metrics",
         "security": [
           {
@@ -1260,7 +1260,7 @@
           "data"
         ],
         "summary": "Get Gpu Utilization Metrics",
-        "description": "Get gpu_utilization metrics for certain MACHINEs between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of GpuUtilizationMeasurement objects",
+        "description": "Get gpu_utilization metrics for certain machines between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of GpuUtilizationMeasurement objects",
         "operationId": "get_gpu_utilization_metrics",
         "security": [
           {
@@ -1449,7 +1449,7 @@
           "data"
         ],
         "summary": "Get Memory Metrics",
-        "description": "Get memory metrics for certain MACHINEs between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of MemoryMeasurement objects",
+        "description": "Get memory metrics for certain machines between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of MemoryMeasurement objects",
         "operationId": "get_memory_metrics",
         "security": [
           {
@@ -1638,7 +1638,7 @@
           "data"
         ],
         "summary": "Get Network Throughput Metrics",
-        "description": "Get network_throughput metrics for certain MACHINEs between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of NetworkThroughputMeasurement objects",
+        "description": "Get network_throughput metrics for certain machines between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of NetworkThroughputMeasurement objects",
         "operationId": "get_network_throughput_metrics",
         "security": [
           {
@@ -1827,7 +1827,7 @@
           "data"
         ],
         "summary": "Get Nvidia Smi Metrics",
-        "description": "Get nvidia_smi metrics for certain MACHINEs between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of NvidiaSmiMeasurement objects",
+        "description": "Get nvidia_smi metrics for certain machines between from_ts to to_ts, inclusive.\n:param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error).\n:param from_ts: Start time filter, inclusive. Optional.\n:param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an\n              error, but the results will be empty.\n:return: List of NvidiaSmiMeasurement objects",
         "operationId": "get_nvidia_smi_metrics",
         "security": [
           {

--- a/rapidui/pyproject.toml
+++ b/rapidui/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "streamlit ~= 1.29.0",
     "centrality-common ~= 0.0.1",
     "typer[all] ~= 0.9.0",
+    "humanize ~= 4.9.0",
 ]
 
 [project.optional-dependencies]

--- a/rapidui/rapidui/app.css
+++ b/rapidui/rapidui/app.css
@@ -40,3 +40,7 @@ hr {
     text-align: center;
 }
 
+thead {
+    visibility: hidden;
+}
+

--- a/rapidui/rapidui/library/machine_info_view.py
+++ b/rapidui/rapidui/library/machine_info_view.py
@@ -1,0 +1,73 @@
+from rapidui.library.flexbox import CardContents, BaseCard
+import datetime
+from typing import Optional
+import pandas as pd
+import humanize
+
+
+class MachineInfoCardContents(CardContents):
+    machine_id: str
+    last_heartbeat_ts_dt: datetime.datetime
+    registration_ts_dt: datetime.datetime
+    num_cpus: int
+    cpu_description: str
+    host_memory_mb: float
+    num_gpus: int
+    gpu_type: Optional[str]
+    gpu_memory_mb: Optional[float]
+    nvidia_driver_version: Optional[str]
+    hostname: str
+
+    @property
+    def last_heartbeat_ts(self):
+        return self.last_heartbeat_ts_dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    @property
+    def registration_ts(self):
+        return self.registration_ts_dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    def as_df(self):
+        memory_human = humanize.naturalsize(
+            self.host_memory_mb * 1024 * 1024, binary=True
+        )
+        df = pd.DataFrame.from_dict(
+            {
+                "Machine ID": [self.machine_id],
+                "Hostname": [self.hostname],
+                "Last Heartbeat": [self.last_heartbeat_ts],
+                "Registration": [self.registration_ts],
+                "CPUs": [self.num_cpus],
+                "CPU Description": [self.cpu_description],
+                "Host Memory": [memory_human],
+                "GPUs": [self.num_gpus],
+            }
+        )
+        if self.num_gpus > 0:
+            gpu_memory_human = humanize.naturalsize(
+                self.gpu_memory_mb * 1024 * 1024, binary=True
+            )
+            df["GPU Type"] = self.gpu_type
+            df["GPU Memory"] = gpu_memory_human
+            df["Nvidia Driver Version"] = self.nvidia_driver_version
+        return df.transpose().astype(str)
+
+
+class MachineInfoCard(BaseCard):
+    def __init__(self, parent_container, contents: MachineInfoCardContents):
+        self.container = parent_container
+        self.contents = contents
+
+        # save all the fields as a table
+        self.table = self.container.empty()
+        self._set_fields()
+
+    def _set_fields(self):
+        self.table.table(data=self.contents.as_df())
+
+    def empty(self):
+        self.table.empty()
+        self.container.empty()
+
+    def update(self, contents: MachineInfoCardContents):
+        self.contents = contents
+        self._set_fields()

--- a/sdk_controlplane/centrality_controlplane_sdk/api/data_api.py
+++ b/sdk_controlplane/centrality_controlplane_sdk/api/data_api.py
@@ -329,7 +329,7 @@ class DataApi:
     ) -> List[CpuMeasurement]:
         """Get Cpu Metrics
 
-        Get cpu metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of CpuMeasurement objects
+        Get cpu metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of CpuMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -406,7 +406,7 @@ class DataApi:
     ) -> ApiResponse[List[CpuMeasurement]]:
         """Get Cpu Metrics
 
-        Get cpu metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of CpuMeasurement objects
+        Get cpu metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of CpuMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -483,7 +483,7 @@ class DataApi:
     ) -> RESTResponseType:
         """Get Cpu Metrics
 
-        Get cpu metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of CpuMeasurement objects
+        Get cpu metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of CpuMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -649,7 +649,7 @@ class DataApi:
     ) -> List[DiskIopsMeasurement]:
         """Get Disk Iops Metrics
 
-        Get disk_iops metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskIopsMeasurement objects
+        Get disk_iops metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskIopsMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -726,7 +726,7 @@ class DataApi:
     ) -> ApiResponse[List[DiskIopsMeasurement]]:
         """Get Disk Iops Metrics
 
-        Get disk_iops metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskIopsMeasurement objects
+        Get disk_iops metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskIopsMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -803,7 +803,7 @@ class DataApi:
     ) -> RESTResponseType:
         """Get Disk Iops Metrics
 
-        Get disk_iops metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskIopsMeasurement objects
+        Get disk_iops metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskIopsMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -969,7 +969,7 @@ class DataApi:
     ) -> List[DiskThroughputMeasurement]:
         """Get Disk Throughput Metrics
 
-        Get disk_throughput metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskThroughputMeasurement objects
+        Get disk_throughput metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskThroughputMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -1046,7 +1046,7 @@ class DataApi:
     ) -> ApiResponse[List[DiskThroughputMeasurement]]:
         """Get Disk Throughput Metrics
 
-        Get disk_throughput metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskThroughputMeasurement objects
+        Get disk_throughput metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskThroughputMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -1123,7 +1123,7 @@ class DataApi:
     ) -> RESTResponseType:
         """Get Disk Throughput Metrics
 
-        Get disk_throughput metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskThroughputMeasurement objects
+        Get disk_throughput metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskThroughputMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -1289,7 +1289,7 @@ class DataApi:
     ) -> List[DiskUsageMeasurement]:
         """Get Disk Usage Metrics
 
-        Get disk_usage metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskUsageMeasurement objects
+        Get disk_usage metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskUsageMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -1366,7 +1366,7 @@ class DataApi:
     ) -> ApiResponse[List[DiskUsageMeasurement]]:
         """Get Disk Usage Metrics
 
-        Get disk_usage metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskUsageMeasurement objects
+        Get disk_usage metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskUsageMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -1443,7 +1443,7 @@ class DataApi:
     ) -> RESTResponseType:
         """Get Disk Usage Metrics
 
-        Get disk_usage metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskUsageMeasurement objects
+        Get disk_usage metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskUsageMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -1609,7 +1609,7 @@ class DataApi:
     ) -> List[GpuMemoryMeasurement]:
         """Get Gpu Memory Metrics
 
-        Get gpu_memory metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of GpuMemoryMeasurement objects
+        Get gpu_memory metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of GpuMemoryMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -1686,7 +1686,7 @@ class DataApi:
     ) -> ApiResponse[List[GpuMemoryMeasurement]]:
         """Get Gpu Memory Metrics
 
-        Get gpu_memory metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of GpuMemoryMeasurement objects
+        Get gpu_memory metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of GpuMemoryMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -1763,7 +1763,7 @@ class DataApi:
     ) -> RESTResponseType:
         """Get Gpu Memory Metrics
 
-        Get gpu_memory metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of GpuMemoryMeasurement objects
+        Get gpu_memory metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of GpuMemoryMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -1929,7 +1929,7 @@ class DataApi:
     ) -> List[GpuUtilizationMeasurement]:
         """Get Gpu Utilization Metrics
 
-        Get gpu_utilization metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of GpuUtilizationMeasurement objects
+        Get gpu_utilization metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of GpuUtilizationMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -2006,7 +2006,7 @@ class DataApi:
     ) -> ApiResponse[List[GpuUtilizationMeasurement]]:
         """Get Gpu Utilization Metrics
 
-        Get gpu_utilization metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of GpuUtilizationMeasurement objects
+        Get gpu_utilization metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of GpuUtilizationMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -2083,7 +2083,7 @@ class DataApi:
     ) -> RESTResponseType:
         """Get Gpu Utilization Metrics
 
-        Get gpu_utilization metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of GpuUtilizationMeasurement objects
+        Get gpu_utilization metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of GpuUtilizationMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -5665,7 +5665,7 @@ class DataApi:
     ) -> List[MemoryMeasurement]:
         """Get Memory Metrics
 
-        Get memory metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of MemoryMeasurement objects
+        Get memory metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of MemoryMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -5742,7 +5742,7 @@ class DataApi:
     ) -> ApiResponse[List[MemoryMeasurement]]:
         """Get Memory Metrics
 
-        Get memory metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of MemoryMeasurement objects
+        Get memory metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of MemoryMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -5819,7 +5819,7 @@ class DataApi:
     ) -> RESTResponseType:
         """Get Memory Metrics
 
-        Get memory metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of MemoryMeasurement objects
+        Get memory metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of MemoryMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -5985,7 +5985,7 @@ class DataApi:
     ) -> List[NetworkThroughputMeasurement]:
         """Get Network Throughput Metrics
 
-        Get network_throughput metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of NetworkThroughputMeasurement objects
+        Get network_throughput metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of NetworkThroughputMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -6062,7 +6062,7 @@ class DataApi:
     ) -> ApiResponse[List[NetworkThroughputMeasurement]]:
         """Get Network Throughput Metrics
 
-        Get network_throughput metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of NetworkThroughputMeasurement objects
+        Get network_throughput metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of NetworkThroughputMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -6139,7 +6139,7 @@ class DataApi:
     ) -> RESTResponseType:
         """Get Network Throughput Metrics
 
-        Get network_throughput metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of NetworkThroughputMeasurement objects
+        Get network_throughput metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of NetworkThroughputMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -6305,7 +6305,7 @@ class DataApi:
     ) -> List[NvidiaSmiMeasurement]:
         """Get Nvidia Smi Metrics
 
-        Get nvidia_smi metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of NvidiaSmiMeasurement objects
+        Get nvidia_smi metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of NvidiaSmiMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -6382,7 +6382,7 @@ class DataApi:
     ) -> ApiResponse[List[NvidiaSmiMeasurement]]:
         """Get Nvidia Smi Metrics
 
-        Get nvidia_smi metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of NvidiaSmiMeasurement objects
+        Get nvidia_smi metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of NvidiaSmiMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]
@@ -6459,7 +6459,7 @@ class DataApi:
     ) -> RESTResponseType:
         """Get Nvidia Smi Metrics
 
-        Get nvidia_smi metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of NvidiaSmiMeasurement objects
+        Get nvidia_smi metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of NvidiaSmiMeasurement objects
 
         :param machine_ids: (required)
         :type machine_ids: List[str]

--- a/sdk_controlplane/docs/DataApi.md
+++ b/sdk_controlplane/docs/DataApi.md
@@ -119,7 +119,7 @@ This endpoint does not need any parameter.
 
 Get Cpu Metrics
 
-Get cpu metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of CpuMeasurement objects
+Get cpu metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of CpuMeasurement objects
 
 ### Example
 
@@ -201,7 +201,7 @@ Name | Type | Description  | Notes
 
 Get Disk Iops Metrics
 
-Get disk_iops metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskIopsMeasurement objects
+Get disk_iops metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskIopsMeasurement objects
 
 ### Example
 
@@ -283,7 +283,7 @@ Name | Type | Description  | Notes
 
 Get Disk Throughput Metrics
 
-Get disk_throughput metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskThroughputMeasurement objects
+Get disk_throughput metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskThroughputMeasurement objects
 
 ### Example
 
@@ -365,7 +365,7 @@ Name | Type | Description  | Notes
 
 Get Disk Usage Metrics
 
-Get disk_usage metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskUsageMeasurement objects
+Get disk_usage metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of DiskUsageMeasurement objects
 
 ### Example
 
@@ -447,7 +447,7 @@ Name | Type | Description  | Notes
 
 Get Gpu Memory Metrics
 
-Get gpu_memory metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of GpuMemoryMeasurement objects
+Get gpu_memory metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of GpuMemoryMeasurement objects
 
 ### Example
 
@@ -529,7 +529,7 @@ Name | Type | Description  | Notes
 
 Get Gpu Utilization Metrics
 
-Get gpu_utilization metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of GpuUtilizationMeasurement objects
+Get gpu_utilization metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of GpuUtilizationMeasurement objects
 
 ### Example
 
@@ -1590,7 +1590,7 @@ Name | Type | Description  | Notes
 
 Get Memory Metrics
 
-Get memory metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of MemoryMeasurement objects
+Get memory metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of MemoryMeasurement objects
 
 ### Example
 
@@ -1672,7 +1672,7 @@ Name | Type | Description  | Notes
 
 Get Network Throughput Metrics
 
-Get network_throughput metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of NetworkThroughputMeasurement objects
+Get network_throughput metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of NetworkThroughputMeasurement objects
 
 ### Example
 
@@ -1754,7 +1754,7 @@ Name | Type | Description  | Notes
 
 Get Nvidia Smi Metrics
 
-Get nvidia_smi metrics for certain MACHINEs between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of NvidiaSmiMeasurement objects
+Get nvidia_smi metrics for certain machines between from_ts to to_ts, inclusive. :param machine_ids: A list of machine ids to get metrics for. Empty list returns no results (but not an error). :param from_ts: Start time filter, inclusive. Optional. :param to_ts: End time filter, inclusive. Optional. If to_ts is before from_ts, there will not be an               error, but the results will be empty. :return: List of NvidiaSmiMeasurement objects
 
 ### Example
 

--- a/tests/e2e/constants.py
+++ b/tests/e2e/constants.py
@@ -1,1 +1,2 @@
 EXPECTED_NUM_AGENTS = 5
+FAKE_AGENT_ID = "fake-data"

--- a/tests/e2e/e2e_test.py
+++ b/tests/e2e/e2e_test.py
@@ -46,8 +46,27 @@ def test_live_machines(docker_compose, sdk: DataApi):
     """
     print_test_function_name()
 
-    live_machines = [m.machine_id for m in sdk.get_live_machines()]
+    live_machines = sdk.get_live_machines()
     asserts.list_size(live_machines, test_constants.EXPECTED_NUM_AGENTS)
+
+    # Find the machine info with id = constants.FAKE_AGENT_ID
+    fake_machine = [
+        m for m in live_machines if m.machine_id == test_constants.FAKE_AGENT_ID
+    ]
+    asserts.list_size(fake_machine, 1)
+    fake_machine = fake_machine[0]
+
+    # Check that the machine info is correct
+    asserts.matches(fake_machine.machine_id, test_constants.FAKE_AGENT_ID)
+    asserts.matches(fake_machine.num_cpus, 8)
+    asserts.matches(
+        fake_machine.cpu_description, "Intel(R) Xeon(R) CPU E5-2676 v3 @ 2.40GHz"
+    )
+    asserts.matches(fake_machine.host_memory_mb, 16000)
+    asserts.matches(fake_machine.num_gpus, 8)
+    asserts.matches(fake_machine.gpu_type, "NVIDIA A100")
+    asserts.matches(fake_machine.gpu_memory_mb, 60000)
+    asserts.matches(fake_machine.nvidia_driver_version, "535.129.03")
 
 
 @pytest.mark.parametrize("metric_type", MetricType)


### PR DESCRIPTION
Add a machine info page. Make the cluster page use the Machine Info correctly so that our CPU/GPU counts are correct. 
Make the metric frequency configurable via environment variable to make development more convenient. Add a test for Machine Info
