### PR TITLE
Add canary service

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,17 @@ To access the DB locally on port 5433:
 fly proxy 5433 -a centrality-datastore-dev
 ```
 
+To deploy the canary which checks that the prod (Fly) control plane is up and running:
+```bash
+fly --config fly-canary.toml deploy
+```
+Note: this requires the `PAGERDUTY_INTEGRATION_KEY` environment variable to be set. See `deploy/deploy/canary/canary.py`.
 
 ## Monorepo
 
-Each of `common`, `controlplane`, `machineagent`, `cli`, `rapidui` and `deploy` are developed as independent Python 
-packages, with many of them having a dependency on `common`. They are versioned together, so the monorepo 
-essentially has a single version number.
+Each of the subprojects are developed as independent Python packages, with many of them having a 
+dependency on `common`. They are versioned together, so the monorepo essentially has a single version 
+number for now.
 
 ## pre-commit
 

--- a/deploy/deploy/canary/README.md
+++ b/deploy/deploy/canary/README.md
@@ -4,3 +4,17 @@ A script that queries the control plane + streamlit to check if it is working. I
 a Pager Duty alert.
 
 TODO: Add fly canary deployment that watches the main deployment.
+
+## Prod
+
+Currently, the Fly deployment is the production deployment. The agent cluster is also part of the prod deployment.
+
+## Failure of the canary
+
+A failure in the canary is an alertable event that must be remediated immediately. Noisy alerts to begin 
+with are fine. 
+
+## PagerDuty
+
+We use PagerDuty to alert if the canary fails. We use the `centrality.dev` PagerDuty account.
+

--- a/deploy/deploy/canary/README.md
+++ b/deploy/deploy/canary/README.md
@@ -3,11 +3,14 @@
 A script that queries the control plane + streamlit to check if it is working. If it is not, it can optionally trigger
 a Pager Duty alert.
 
-TODO: Add fly canary deployment that watches the main deployment.
 
 ## Prod
 
 Currently, the Fly deployment is the production deployment. The agent cluster is also part of the prod deployment.
+
+## Canary deployment
+
+The canary is deployed to Fly as a separate application. It is deployed using the `fly-canary.toml` config file.
 
 ## Failure of the canary
 

--- a/deploy/deploy/canary/README.md
+++ b/deploy/deploy/canary/README.md
@@ -1,0 +1,6 @@
+# Canary
+
+A script that queries the control plane + streamlit to check if it is working. If it is not, it can optionally trigger
+a Pager Duty alert.
+
+TODO: Add fly canary deployment that watches the main deployment.

--- a/deploy/deploy/canary/canary.py
+++ b/deploy/deploy/canary/canary.py
@@ -1,0 +1,95 @@
+from common.sdks.controlplane.sdk import ControlPlaneSdkConfig, get_sdk
+from pydantic import BaseModel
+from common import constants
+import requests
+from rich.console import Console
+from centrality_controlplane_sdk import DataApi
+import time
+
+console = Console()
+
+
+class PagerDutyAlerter:
+    def __init__(self):
+        # TODO: Validate that the environment variables are set correctly
+        pass
+
+    def alert(self, msg: str):
+        # TODO: Implement proper
+        console.log(msg)
+
+
+class FailedHealthcheckError(Exception):
+    pass
+
+
+class StreamlitConfig(BaseModel):
+    host: str = "localhost"
+    port: int = 8501
+    https: bool = False
+
+    @property
+    def host_str(self) -> str:
+        scheme = "https" if self.https else "http"
+        return f"{scheme}://{self.host}:{self.port}"
+
+
+def run_control_plane_healthcheck(sdk: DataApi):
+    try:
+        sdk.get_healthcheck()
+        assert len(sdk.get_live_machines()) > 0
+        console.log("✅  Control plane is healthy")
+    except Exception as e:
+        raise FailedHealthcheckError(f"Control plane healthcheck failed: {e}")
+
+
+def run_streamlit_healthcheck(config: StreamlitConfig):
+    try:
+        response = requests.get(f"{config.host_str}/healthz")
+        assert response.status_code == 200
+        console.log("✅  Streamlit is healthy")
+    except Exception as e:
+        raise FailedHealthcheckError(f"Streamlit healthcheck failed: {e}")
+
+
+def main(
+    control_plane_config: ControlPlaneSdkConfig,
+    streamlit_config: StreamlitConfig,
+    healthcheck_interval: int,
+):
+    sdk = get_sdk(control_plane_config, token=constants.CONTROL_PLANE_SDK_DEV_TOKEN)
+    alerter = PagerDutyAlerter()
+
+    while True:
+        try:
+            run_control_plane_healthcheck(sdk)
+        except FailedHealthcheckError as e:
+            alerter.alert(f"❌️ {e}")
+        except Exception as e:
+            alerter.alert(
+                f"❌️ Unexpected error while healthchecking control plane: {e}"
+            )
+
+        try:
+            run_streamlit_healthcheck(streamlit_config)
+        except FailedHealthcheckError as e:
+            alerter.alert(f"❌️ {e}")
+        except Exception as e:
+            alerter.alert(f"❌️ Unexpected error while healthchecking streamlit: {e}")
+        finally:
+            time.sleep(healthcheck_interval)
+
+
+if __name__ == "__main__":
+    config = ControlPlaneSdkConfig(
+        host="localhost",
+        port=8000,
+        https=False,
+    )
+    streamlit_config = StreamlitConfig(
+        host="localhost",
+        port=8501,
+        https=False,
+    )
+
+    main(config, streamlit_config, healthcheck_interval=5)

--- a/deploy/deploy/canary/canary.py
+++ b/deploy/deploy/canary/canary.py
@@ -37,7 +37,8 @@ class StreamlitConfig(BaseModel):
 def run_control_plane_healthcheck(sdk: DataApi):
     try:
         sdk.get_healthcheck()
-        assert len(sdk.get_live_machines()) > 0
+        if len(sdk.get_live_machines()) <= 0:
+            raise FailedHealthcheckError("no live machines")
         console.log("✅  Control plane is healthy")
     except Exception as e:
         raise FailedHealthcheckError(f"Control plane healthcheck failed: {e}")
@@ -46,7 +47,8 @@ def run_control_plane_healthcheck(sdk: DataApi):
 def run_streamlit_healthcheck(config: StreamlitConfig):
     try:
         response = requests.get(f"{config.host_str}/healthz")
-        assert response.status_code == 200
+        if response.status_code != 200:
+            raise FailedHealthcheckError(f"Response code not 200: {response}")
         console.log("✅  Streamlit is healthy")
     except Exception as e:
         raise FailedHealthcheckError(f"Streamlit healthcheck failed: {e}")

--- a/deploy/pyproject.toml
+++ b/deploy/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "rich ~= 13.7.0",
     "boto3 ~= 1.34.7",
     "typer[all] ~= 0.9.0",
+    "pdpyras",
 ]
 
 [project.optional-dependencies]

--- a/fly-canary.toml
+++ b/fly-canary.toml
@@ -1,0 +1,26 @@
+# fly.toml app configuration file generated for centrality-canary on 2024-01-20T23:25:26-08:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "centrality-canary"
+primary_region = "sjc"
+
+[build]
+
+[http_service]
+  internal_port = 7777
+  force_https = true
+  min_machines_running = 1
+  processes = ["canary"]
+
+[processes]
+  canary = "python deploy/deploy/canary/canary.py prod --pagerduty"
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 256
+
+[env]
+  PYTHONUNBUFFERED = 1


### PR DESCRIPTION
Add a basic canary service that checks if the control plane (and streamlit backend) are passing basic healthchecks. Deploy this to fly. 

Not this is not automatically deployed with the other Fly deployments